### PR TITLE
Enable hstore, add commands hash to user model

### DIFF
--- a/db/migrate/20150314235630_add_hstore.rb
+++ b/db/migrate/20150314235630_add_hstore.rb
@@ -1,0 +1,9 @@
+class AddHstore < ActiveRecord::Migration
+  def up
+    enable_extension :hstore
+  end
+
+  def down
+    disable_extension :hstore
+  end
+end

--- a/db/migrate/20150315000155_add_commands_to_user.rb
+++ b/db/migrate/20150315000155_add_commands_to_user.rb
@@ -1,0 +1,5 @@
+class AddCommandsToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :commands, :hstore, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150311204513) do
+ActiveRecord::Schema.define(version: 20150315000155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "users", force: :cascade do |t|
     t.string   "github_id"
     t.string   "name"
     t.string   "picture"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.hstore   "commands",   default: {}
   end
 
 end


### PR DESCRIPTION
This migration enables the `hstore` data type in postgres and adds the the commands column to the user database.